### PR TITLE
:wrench: Configure Promethes operator to look into all namespaces

### DIFF
--- a/apps/prometheus/helm-release.yaml
+++ b/apps/prometheus/helm-release.yaml
@@ -20,6 +20,10 @@ spec:
         podAntiAffinity: hard
         replicas: 3
         retention: 14d
+        podMonitorSelectorNilUsesHelmValues: false
+        probeSelectorNilUsesHelmValues: false
+        ruleSelectorNilUsesHelmValues: false
+        serviceMonitorSelectorNilUsesHelmValues: false
         storageSpec:
           volumeClaimTemplate:
             spec:


### PR DESCRIPTION
Let Prometheus look in all namespaces for custom resources. These settings are not intuitive, but here we go.