### PR TITLE
:truck: Remove 'apps' subdomain

### DIFF
--- a/apps/grafana/helm-release.yaml
+++ b/apps/grafana/helm-release.yaml
@@ -22,11 +22,11 @@ spec:
         traefik.ingress.kubernetes.io/router.entrypoints: websecure,web
         traefik.ingress.kubernetes.io/router.tls: "true"
       hosts:
-      - grafana.apps.chaosdorf.space
+      - grafana.chaosdorf.space
       tls:
       - secretName: grafana-tls
         hosts:
-        - grafana.apps.chaosdorf.space
+        - grafana.chaosdorf.space
     grafana.ini:
       auth.anonymous:
         enabled: true

--- a/apps/kubernetes-dashboard/helm-release.yaml
+++ b/apps/kubernetes-dashboard/helm-release.yaml
@@ -25,11 +25,11 @@ spec:
         traefik.ingress.kubernetes.io/router.entrypoints: websecure,web
         traefik.ingress.kubernetes.io/router.tls: "true"
       hosts:
-        - kubernetes.apps.chaosdorf.space
+        - kubernetes.chaosdorf.space
       tls:
         - secretName: kubernetes-dashboard-tls
           hosts:
-          - kubernetes.apps.chaosdorf.space
+          - kubernetes.chaosdorf.space
       customPaths:
         - path: /
           pathType: ImplementationSpecific

--- a/apps/labello/ingress.yaml
+++ b/apps/labello/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
   rules:
-    - host: labello.apps.chaosdorf.space
+    - host: labello.chaosdorf.space
       http:
         paths:
           - path: /
@@ -18,5 +18,5 @@ spec:
                   number: 80
   tls:
     - hosts:
-      - labello.apps.chaosdorf.space
+      - labello.chaosdorf.space
       secretName: ingress-tls

--- a/apps/netbox/helm-release.yaml
+++ b/apps/netbox/helm-release.yaml
@@ -24,10 +24,10 @@ spec:
         traefik.ingress.kubernetes.io/router.entrypoints: websecure,web
         traefik.ingress.kubernetes.io/router.tls: "true"
       hosts:
-      - host: netbox.apps.chaosdorf.space
+      - host: netbox.chaosdorf.space
         paths:
         - /
       tls:
       - secretName: netbox-tls
         hosts:
-        - netbox.apps.chaosdorf.space
+        - netbox.chaosdorf.space


### PR DESCRIPTION
Since #52, we don't need this anymore.
