### PR TITLE
Install Mopidy Helm Chart

### DIFF
--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - prometheus
   - snmp-exporter
   - snapcast-server
+  - mopidy

--- a/apps/mopidy/helm-release.yaml
+++ b/apps/mopidy/helm-release.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: mopidy
+
+spec:
+  interval: 1h
+  install:
+    createNamespace: false
+
+  chart:
+    spec:
+      chart: mopidy
+      sourceRef:
+        kind: HelmRepository
+        name: mopidy
+
+  values: {}

--- a/apps/mopidy/helm-repository.yaml
+++ b/apps/mopidy/helm-repository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: mopidy
+
+spec:
+  url: https://lukasklinger.github.io/mopidy-k8s
+  interval: 1h

--- a/apps/mopidy/kustomization.yaml
+++ b/apps/mopidy/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: mopidy
+resources:
+- helm-release.yaml
+- helm-repository.yaml
+- namespace.yaml

--- a/apps/mopidy/namespace.yaml
+++ b/apps/mopidy/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mopidy


### PR DESCRIPTION
PR installs a Mopidy Helm chart to use in combination with Snapcast.

> Mopidy is a free, open-source music server that allows users to stream music from various sources, including local files, Spotify, SoundCloud, Google Play Music, and more. It can also be controlled remotely via a web interface or various mobile apps, making it a versatile and easy-to-use music solution. Mopidy is written in Python and can run on various operating systems, including Linux, Windows, and macOS. It is used by individuals, music enthusiasts, and businesses to stream music and create custom music experiences.