### PR TITLE
:sparkles: Configure Rook Ceph storage cluster

### DIFF
--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - netbox
   - ping-exporter
   - prometheus
+  - rook-cluster
   - snmp-exporter
   - snapcast-server
   - mopidy

--- a/apps/rook-cluster/helm-release.yaml
+++ b/apps/rook-cluster/helm-release.yaml
@@ -19,6 +19,34 @@ spec:
     cephClusterSpec:
       dashboard:
         enabled: true
+      resources:
+        mgr:
+          requests:
+            cpu: 50m
+        mon:
+          requests:
+            cpu: 100m
+        osd:
+          requests:
+            cpu: 100m
+        prepareosd:
+          requests:
+            cpu: 50m
+        mgr-sidecar:
+          requests:
+            cpu: 10m
+        crashcollector:
+          requests:
+            cpu: 10m
+        logcollector:
+          requests:
+            cpu: 10m
+        cleanup:
+          requests:
+            cpu: 50m
+        exporter:
+          requests:
+            cpu: 5m
     ingress:
       dashboard:
         annotations:

--- a/apps/rook-cluster/helm-release.yaml
+++ b/apps/rook-cluster/helm-release.yaml
@@ -16,13 +16,15 @@ spec:
     monitoring:
       enabled: true
       createPrometheusRules: true
-    ingress:
+    cephClusterSpec:
       dashboard:
         enabled: true
+    ingress:
+      dashboard:
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt-prod
-        hosts:
-        - rook.chaosdorf.space
+        host:
+          name: rook.chaosdorf.space
         tls:
         - secretName: rook-tls
           hosts:

--- a/apps/rook-cluster/helm-release.yaml
+++ b/apps/rook-cluster/helm-release.yaml
@@ -1,0 +1,29 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: rook-ceph-cluster
+spec:
+  interval: 1h
+  install:
+    createNamespace: false
+  chart:
+    spec:
+      chart: rook-ceph-cluster
+      sourceRef:
+        kind: HelmRepository
+        name: rook-release
+  values:
+    monitoring:
+      enabled: true
+      createPrometheusRules: true
+    ingress:
+      dashboard:
+        enabled: true
+        annotations:
+          cert-manager.io/cluster-issuer: letsencrypt-prod
+        hosts:
+        - rook.chaosdorf.space
+        tls:
+        - secretName: rook-tls
+          hosts:
+            - rook.chaosdorf.space

--- a/apps/rook-cluster/helm-repository.yaml
+++ b/apps/rook-cluster/helm-repository.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: rook-release
+spec:
+  url: https://charts.rook.io/release
+  interval: 1h

--- a/apps/rook-cluster/kustomization.yaml
+++ b/apps/rook-cluster/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: rook-cluster
+resources:
+ - helm-release.yaml
+ - helm-repository.yaml
+ - namespace.yaml

--- a/apps/rook-cluster/namespace.yaml
+++ b/apps/rook-cluster/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rook-cluster

--- a/infra/kustomization.yaml
+++ b/infra/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
   - cert-manager
   - external-dns
   - metallb
+  - rook-ceph
   - secret-generator

--- a/infra/rook-ceph/helm-release.yaml
+++ b/infra/rook-ceph/helm-release.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: rook-ceph
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: rook-ceph
+      sourceRef:
+        kind: HelmRepository
+        name: rook-release
+      interval: 1h
+  values:
+    monitoring:
+      enabled: true
+    resources:
+      requests:
+        cpu: 10m
+    csi:
+      csiRBDProvisionerResource: |
+        - name : csi-provisioner
+          resource:
+            requests:
+              cpu: 10m
+        - name : csi-resizer
+          resource:
+            requests:
+              cpu: 10m
+        - name : csi-attacher
+          resource:
+            requests:
+              cpu: 10m
+        - name : csi-snapshotter
+          resource:
+            requests:
+              cpu: 10m
+        - name : csi-rbdplugin
+          resource:
+            requests:
+              cpu: 25m
+        - name : csi-omap-generator
+          resource:
+            requests:
+              cpu: 25m
+        - name : liveness-prometheus
+          resource:
+            requests:
+              cpu: 5m
+      csiRBDPluginResource: |
+        - name : driver-registrar
+          resource:
+            requests:
+              cpu: 5m
+        - name : csi-rbdplugin
+          resource:
+            requests:
+              cpu: 25m
+        - name : liveness-prometheus
+          resource:
+            requests:
+              cpu: 5m
+      csiCephFSProvisionerResource: |
+        - name : csi-provisioner
+          resource:
+            requests:
+              cpu: 10m
+        - name : csi-resizer
+          resource:
+            requests:
+              cpu: 10m
+        - name : csi-attacher
+          resource:
+            requests:
+              cpu: 10m
+        - name : csi-snapshotter
+          resource:
+            requests:
+              cpu: 10m
+        - name : csi-cephfsplugin
+          resource:
+            requests:
+              cpu: 25m
+        - name : liveness-prometheus
+          resource:
+            requests:
+              cpu: 5m

--- a/infra/rook-ceph/helm-repository.yaml
+++ b/infra/rook-ceph/helm-repository.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: rook-release
+spec:
+  url: https://charts.rook.io/release
+  interval: 1h

--- a/infra/rook-ceph/kustomization.yaml
+++ b/infra/rook-ceph/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: rook-ceph
+resources:
+- helm-release.yaml
+- helm-repository.yaml
+- namespace.yaml

--- a/infra/rook-ceph/namespace.yaml
+++ b/infra/rook-ceph/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rook-ceph


### PR DESCRIPTION
This deploys the Rook operator for Ceph and creates a cluster configuration. Unused disks on all nodes will be used automatically. We gain new storage classes for persistent volumes!