### PR TITLE
netbox media persistence

### DIFF
--- a/apps/netbox/helm-release.yaml
+++ b/apps/netbox/helm-release.yaml
@@ -31,3 +31,7 @@ spec:
       - secretName: netbox-tls
         hosts:
         - netbox-beta.chaosdorf.space
+    persistence:
+      storageClass: ceph-filesystem
+      accessMode: ReadWriteMany
+      size: 16Gi


### PR DESCRIPTION
- :truck: Move NetBox to netbox-beta.chaosdorf.space
- :wrench: Configure persistence for NetBox media files
