### PR TITLE
:wrench: Configure Prometheus to only 1 replica

### DIFF
--- a/apps/prometheus/helm-release.yaml
+++ b/apps/prometheus/helm-release.yaml
@@ -18,7 +18,6 @@ spec:
     prometheus:
       prometheusSpec:
         podAntiAffinity: hard
-        replicas: 3
         retention: 14d
         podMonitorSelectorNilUsesHelmValues: false
         probeSelectorNilUsesHelmValues: false


### PR DESCRIPTION
If using a non-replicating application like Prometheus with multiple instances, we will only get inconsistent data.
For high-availability, we need some other app.
