### PR TITLE
:truck: Migrate Loki Helm chart

### DIFF
--- a/apps/loki/helm-release.yaml
+++ b/apps/loki/helm-release.yaml
@@ -9,7 +9,7 @@ spec:
     createNamespace: false
   chart:
     spec:
-      chart: loki-stack
+      chart: loki
       sourceRef:
         kind: HelmRepository
         name: grafana


### PR DESCRIPTION
Move from deprecated Helm chart to maintained one.
