### PR TITLE
fix(apps): Another copyparty fix!

### DIFF
--- a/apps/copyparty/helm-release.yaml
+++ b/apps/copyparty/helm-release.yaml
@@ -13,7 +13,7 @@ spec:
         kind: HelmRepository
         name: copyparty
   values:
-    command: 
+    command: null
     args:
       - -v
       - /w::rwmd

--- a/apps/copyparty/helm-release.yaml
+++ b/apps/copyparty/helm-release.yaml
@@ -13,9 +13,14 @@ spec:
         kind: HelmRepository
         name: copyparty
   values:
-    image:
-      repository: ghcr.io/9001/copyparty-ac
-      tag: 1.19.5
+    command: 
+    args:
+      - -v
+      - /w::rwmd
+      - --xff-src
+      - lan
+      - --rproxy
+      - -1
     ingress:
       enabled: true
       annotations:
@@ -29,13 +34,6 @@ spec:
         - hosts:
             - copyparty.chaosdorf.space
           secretName: ingress-tls
-    args:
-      - -v
-      - /w::rwmd
-      - --xff-src
-      - lan
-      - --rproxy
-      - -1
     resources:
       limits:
         cpu: '1'


### PR DESCRIPTION
whoops, if we want to unset a value from a helm chart, we can't just leave it empty. we need to set it to `null`.